### PR TITLE
fix: HandleChange's EventType

### DIFF
--- a/src/lib-ts/index.tsx
+++ b/src/lib-ts/index.tsx
@@ -46,7 +46,7 @@ interface StepProps {
 	beforeStepChange?: BeforeStepChange;
 }
 
-type EventType = React.ChangeEvent<HTMLInputElement> &
+type EventType = React.ChangeEvent<HTMLInputElement> |
 	React.ChangeEvent<HTMLTextAreaElement>;
 
 type AllSteps = { order: number; title: string }[];


### PR DESCRIPTION
The event can't be both : `React.ChangeEvent<HTMLInputElement>` and `React.ChangeEvent<HTMLTextAreaElement>`